### PR TITLE
Refactoring of error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "anyhow"
-version = "1.0.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,7 +12,6 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 name = "mbox"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "bytes",
  "thiserror",
 ]

--- a/mbox/Cargo.toml
+++ b/mbox/Cargo.toml
@@ -6,6 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.72"
 bytes = "1.4.0"
 thiserror = "1.0.44"

--- a/mbox/src/lib.rs
+++ b/mbox/src/lib.rs
@@ -2,16 +2,24 @@
 mod macros;
 mod buf;
 mod io;
-pub mod mbox;
+mod mbox;
 
 use crate::buf::{Buf, Status};
 use crate::mbox::find_from;
-use anyhow::{anyhow, Result};
 use std::io::Read;
+use thiserror::Error;
 
 pub struct Parser {
     reader: Box<dyn Read>,
     buf: Buf,
+}
+
+#[derive(Error, Debug)]
+pub enum ParseError {
+    #[error("Expected 'From ' at beginning of input is missing")]
+    MissingFirstFrom,
+    #[error("Reading caused io::Error")]
+    ReadError(#[from] std::io::Error),
 }
 
 impl Parser {
@@ -26,17 +34,17 @@ impl Parser {
         }
     }
 
-    pub fn get_messages(&mut self) -> Result<Vec<String>> {
+    pub fn get_messages(&mut self) -> Result<Vec<String>, ParseError> {
         let mut message: Vec<String> = Vec::new();
 
-        let mut first = false;
+        let mut first = true;
 
-        while let Ok(Status::Success) = self.buf.fill(&mut self.reader) {
+        while let Status::Success = self.buf.fill(&mut self.reader)? {
             if first {
                 // The first message is a special case, as there is no double newline from the
                 // previous message to match on
                 if !self.buf.peek().starts_with(b"From ") {
-                    return Err(anyhow!("File doesn't start with the expected 'From '"));
+                    return Err(ParseError::MissingFirstFrom);
                 }
                 first = false;
             }
@@ -58,7 +66,7 @@ fn inner_get_message(messages: &mut Vec<String>, buf: &mut Buf) {
         // why + 2? Because the first part of the matching string, "\n\n" could be
         // thought of as in between the messages. Another side effect of this is that
         // find_from() now won't match at pos 0 the next time around.
-        buf.consume(pos + 2).unwrap();
+        buf.consume(pos + 2);
         slice = buf.peek();
     }
 }
@@ -72,6 +80,7 @@ const BUF_SIZE: usize = 8192;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::ErrorKind;
 
     #[test]
     fn test_get_messages() {
@@ -90,5 +99,29 @@ mod tests {
         let mut parser = Parser::with_buf_size(Box::new(r!(msg)), 15);
         let result = parser.get_messages().unwrap();
         assert_eq!(vec!["From abc", "From cde", "From xyz", "From zzt"], result);
+    }
+
+    struct ErrorReader;
+
+    impl Read for ErrorReader {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(ErrorKind::Other.into())
+        }
+    }
+
+    #[test]
+    fn test_get_messages_with_io_error() {
+        let mut parser = Parser::new(Box::new(ErrorReader {}));
+        let result = parser.get_messages();
+        assert!(matches!(result, Err(ParseError::ReadError(i)) if i.kind() == ErrorKind::Other));
+    }
+
+    #[test]
+    fn test_get_messages_without_leading_from() {
+        let mut parser = Parser::new(Box::new(r!("No From in the beginning")));
+        assert!(matches!(
+            parser.get_messages(),
+            Err(ParseError::MissingFirstFrom)
+        ));
     }
 }


### PR DESCRIPTION
Use custom errors with thiserror instead of anyhow. Add test cases for failure modes. Fix buf in signalling that "From " needs to be at the beginning of input